### PR TITLE
Update SurviveJS bits (#16)

### DIFF
--- a/react-tutorials.md
+++ b/react-tutorials.md
@@ -136,7 +136,10 @@
   http://codeutopia.net/blog/2016/02/08/using-webrtc-and-react-to-build-a-basic-chat-server/  
   http://codeutopia.net/blog/2016/02/15/improving-our-react-workflow-with-es6-and-functional-stateless-components/  
   A multi-part series that builds up a chat application
-  
+
+- **SurviveJS - React**  
+  http://survivejs.com/react/introduction  
+  A full book online book that shows how to develop a Kanban application. Covers key ideas of React, Flux, and advanced concepts such as styling. The commercial version has more content, but you can complete the basic tutorial for free.  
 
 #### React Implementation Walkthroughs
   

--- a/webpack-tutorials.md
+++ b/webpack-tutorials.md
@@ -2,13 +2,9 @@
 
 
 #### Basic Tutorials
-- **SurviveJS**  
-  http://survivejs.com/  
-  A full book online book that covers setting up Webpack, developing using React and Flux, and using ESLint for code quality
-
 - **SurviveJS - Webpack**  
-  http://survivejs.com/webpack/  
-  A follow-up book focused on Webpack usage.  Still a work in progress, but good.
+  http://survivejs.com/webpack/introduction  
+  A full book online book that covers setting up Webpack for both development and production. Also touches topics such as ESLint and npm.
 
 - **Beginner's Guide to Webpack**  
   https://medium.com/@dabit3/beginner-s-guide-to-webpack-b1f1a3638460  


### PR DESCRIPTION
# Formatting

Please follow the existing formatting for each entry.  In order to get newlines without paragraph breaks, each entry should have two spaces at the end of the line after both the URL and the title.  Also, two-space indents before the URL and the description.  Example:

```markdown
- **Link Title**<space><space>  
<space><space>http://example.com<space><space>  
<space><space>Link description here
```

Result:

- **Link Title**  
  http://example.com  
  Link description here
  
Please do _not_ strip whitespace for existing entries!

Updated to reflect the split state. Now it's two books/tutorials instead
of one.